### PR TITLE
updated to authelia migration

### DIFF
--- a/lib/data/appData.ts
+++ b/lib/data/appData.ts
@@ -34,12 +34,6 @@ const ticketsystem: AppData = {
   linkToApp: 'https://tickets.mathphys.stura.uni-heidelberg.de/'
 }
 
-//const notesIntern: AppData = {
-//  name: 'Notes (intern)',
-//  imagePath: '/icons_light/notes_intern.png',
-//  altText: 'Hedgedoc Icon',
-//  linkToApp: 'https://notes.mathphys.stura.uni-heidelberg.de/'
-//}
 
 const notesPublic: AppData = {
   name: 'Notes (public)',


### PR DESCRIPTION
I updated the "mathphys.info" links to "mathphys.stura.uni-heidelberg.de". I also removed the sumpf and the internal notes because they will no longer be supported, also updated the wordpress link